### PR TITLE
Add Flask app with role-based permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+instance/
+*.db

--- a/app.py
+++ b/app.py
@@ -1,0 +1,213 @@
+from flask import Flask, render_template, redirect, url_for, request, flash
+from flask_sqlalchemy import SQLAlchemy
+from flask_login import LoginManager, UserMixin, login_user, logout_user, login_required, current_user
+from werkzeug.security import generate_password_hash, check_password_hash
+import os
+
+app = Flask(__name__)
+app.config['SECRET_KEY'] = 'secret-key'
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///stok.db'
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+
+db = SQLAlchemy(app)
+login_manager = LoginManager(app)
+login_manager.login_view = 'login'
+
+# Association table for role-menu permissions
+role_menus = db.Table('role_menus',
+    db.Column('role_id', db.Integer, db.ForeignKey('role.id')),
+    db.Column('menu_id', db.Integer, db.ForeignKey('menu.id'))
+)
+
+class Role(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(64), unique=True, nullable=False)
+    menus = db.relationship('Menu', secondary=role_menus, backref='roles')
+
+class Department(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(64), unique=True, nullable=False)
+
+class User(UserMixin, db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(64), unique=True, nullable=False)
+    password_hash = db.Column(db.String(128), nullable=False)
+    role_id = db.Column(db.Integer, db.ForeignKey('role.id'))
+    department_id = db.Column(db.Integer, db.ForeignKey('department.id'))
+    role = db.relationship('Role')
+    department = db.relationship('Department')
+
+    def set_password(self, password):
+        self.password_hash = generate_password_hash(password)
+
+    def check_password(self, password):
+        return check_password_hash(self.password_hash, password)
+
+class Menu(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    module = db.Column(db.String(64), nullable=False)
+    name = db.Column(db.String(64), nullable=False)
+
+@login_manager.user_loader
+def load_user(user_id):
+    return User.query.get(int(user_id))
+
+def init_db():
+    db.create_all()
+    # create default roles and menus if not exist
+    if not Role.query.filter_by(name='Admin').first():
+        admin_role = Role(name='Admin')
+        db.session.add(admin_role)
+        db.session.commit()
+    if not Menu.query.first():
+        menus = [
+            ('Kartlar', 'Stok Kartları'), ('Kartlar', 'Masraf Yeri Kartları'),
+            ('Kartlar', 'Lokasyon Kartları'), ('Kartlar', 'Birim Kartları'),
+            ('Kartlar', 'Kategori Kartları'), ('Hareketler', 'Talep Girişi'),
+            ('Hareketler', 'Fatura Girişi'), ('Hareketler', 'Mal Girişi'),
+            ('Hareketler', 'Üretime Çıkış'), ('Raporlar', 'Alım Raporları'),
+            ('Raporlar', 'Çıkış Raporları'), ('Raporlar', 'Stok Raporları'),
+            ('Yönetim', 'Kullanıcı Ekle'), ('Yönetim', 'Departman Ekle'),
+            ('Yönetim', 'Yetki Tanımlama')
+        ]
+        for module, name in menus:
+            db.session.add(Menu(module=module, name=name))
+        db.session.commit()
+    if not User.query.filter_by(username='admin').first():
+        admin = User(username='admin', role=Role.query.filter_by(name='Admin').first())
+        admin.set_password('admin')
+        db.session.add(admin)
+        db.session.commit()
+
+@app.route('/')
+@login_required
+def index():
+    return render_template('index.html')
+
+@app.route('/login', methods=['GET', 'POST'])
+def login():
+    if request.method == 'POST':
+        user = User.query.filter_by(username=request.form['username']).first()
+        if user and user.check_password(request.form['password']):
+            login_user(user)
+            return redirect(url_for('index'))
+        flash('Invalid credentials')
+    return render_template('login.html')
+
+@app.route('/logout')
+@login_required
+def logout():
+    logout_user()
+    return redirect(url_for('login'))
+
+# Utility decorator to check permission
+from functools import wraps
+
+def permission_required(menu_name):
+    def decorator(f):
+        @wraps(f)
+        def decorated_function(*args, **kwargs):
+            if current_user.role.name == 'Admin':
+                return f(*args, **kwargs)
+            menu = Menu.query.filter_by(name=menu_name).first()
+            if not menu or menu not in current_user.role.menus:
+                flash('Yetkiniz yok')
+                return redirect(url_for('index'))
+            return f(*args, **kwargs)
+        return decorated_function
+    return decorator
+
+# Management Views
+@app.route('/management/users')
+@login_required
+@permission_required('Kullanıcı Ekle')
+def manage_users():
+    users = User.query.all()
+    roles = Role.query.all()
+    departments = Department.query.all()
+    return render_template('manage_users.html', users=users, roles=roles, departments=departments)
+
+@app.route('/management/users/add', methods=['POST'])
+@login_required
+@permission_required('Kullanıcı Ekle')
+def add_user():
+    username = request.form['username']
+    password = request.form['password']
+    role_id = request.form.get('role_id')
+    department_id = request.form.get('department_id')
+    user = User(username=username, role_id=role_id, department_id=department_id)
+    user.set_password(password)
+    db.session.add(user)
+    db.session.commit()
+    return redirect(url_for('manage_users'))
+
+@app.route('/management/users/delete/<int:user_id>')
+@login_required
+@permission_required('Kullanıcı Ekle')
+def delete_user(user_id):
+    if current_user.id == user_id:
+        flash('Kendi hesabınızı silemezsiniz')
+        return redirect(url_for('manage_users'))
+    user = User.query.get(user_id)
+    if user:
+        db.session.delete(user)
+        db.session.commit()
+    return redirect(url_for('manage_users'))
+
+@app.route('/management/departments')
+@login_required
+@permission_required('Departman Ekle')
+def manage_departments():
+    departments = Department.query.all()
+    return render_template('manage_departments.html', departments=departments)
+
+@app.route('/management/departments/add', methods=['POST'])
+@login_required
+@permission_required('Departman Ekle')
+def add_department():
+    name = request.form['name']
+    db.session.add(Department(name=name))
+    db.session.commit()
+    return redirect(url_for('manage_departments'))
+
+@app.route('/management/departments/delete/<int:dept_id>')
+@login_required
+@permission_required('Departman Ekle')
+def delete_department(dept_id):
+    dept = Department.query.get(dept_id)
+    if dept:
+        db.session.delete(dept)
+        db.session.commit()
+    return redirect(url_for('manage_departments'))
+
+@app.route('/management/permissions', methods=['GET', 'POST'])
+@login_required
+@permission_required('Yetki Tanımlama')
+def manage_permissions():
+    roles = Role.query.all()
+    menus = Menu.query.all()
+    role = None
+    if request.method == 'POST':
+        role_id = request.form['role_id']
+        role = Role.query.get(role_id)
+        if 'menus' in request.form:
+            selected = request.form.getlist('menus')
+            role.menus = [Menu.query.get(int(mid)) for mid in selected]
+            db.session.commit()
+            return redirect(url_for('manage_permissions'))
+    elif request.args.get('role_id'):
+        role = Role.query.get(request.args.get('role_id'))
+    return render_template('manage_permissions.html', roles=roles, menus=menus, role=role)
+
+# Example module route
+@app.route('/kartlar/stok')
+@login_required
+@permission_required('Stok Kartları')
+def stok_kartlari():
+    return render_template('module.html', title='Stok Kartları')
+
+if __name__ == '__main__':
+    if not os.path.exists('stok.db'):
+        with app.app_context():
+            init_db()
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Flask
+Flask-Login
+Flask-SQLAlchemy
+Werkzeug

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<title>Stok Takip</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+<nav class="navbar navbar-expand-lg navbar-light bg-light">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="{{ url_for('index') }}">Stok Takip</a>
+    <div class="collapse navbar-collapse">
+      <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+        {% if current_user.is_authenticated %}
+          <li class="nav-item"><a class="nav-link" href="{{ url_for('logout') }}">Logout</a></li>
+        {% endif %}
+      </ul>
+    </div>
+  </div>
+</nav>
+<div class="container mt-4">
+  {% with messages = get_flashed_messages() %}
+    {% if messages %}
+      <div class="alert alert-warning">{{ messages[0] }}</div>
+    {% endif %}
+  {% endwith %}
+  {% block content %}{% endblock %}
+</div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Hoşgeldiniz {{ current_user.username }}</h2>
+<ul>
+  <li><a href="{{ url_for('manage_users') }}">Kullanıcı Yönetimi</a></li>
+  <li><a href="{{ url_for('manage_departments') }}">Departman Yönetimi</a></li>
+  <li><a href="{{ url_for('manage_permissions') }}">Yetki Tanımlama</a></li>
+  <li><a href="{{ url_for('stok_kartlari') }}">Stok Kartları</a></li>
+</ul>
+{% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Login</h2>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Username</label>
+    <input class="form-control" type="text" name="username">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Password</label>
+    <input class="form-control" type="password" name="password">
+  </div>
+  <button class="btn btn-primary" type="submit">Login</button>
+</form>
+{% endblock %}

--- a/templates/manage_departments.html
+++ b/templates/manage_departments.html
@@ -1,0 +1,19 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Departmanlar</h2>
+<table class="table">
+  <tr><th>ID</th><th>İsim</th><th></th></tr>
+  {% for d in departments %}
+  <tr>
+    <td>{{ d.id }}</td>
+    <td>{{ d.name }}</td>
+    <td><a class="btn btn-sm btn-danger" href="{{ url_for('delete_department', dept_id=d.id) }}">Sil</a></td>
+  </tr>
+  {% endfor %}
+</table>
+<h3>Yeni Departman</h3>
+<form method="post" action="{{ url_for('add_department') }}">
+  <div class="mb-3"><input class="form-control" name="name" placeholder="Departman Adı"></div>
+  <button class="btn btn-primary" type="submit">Ekle</button>
+</form>
+{% endblock %}

--- a/templates/manage_permissions.html
+++ b/templates/manage_permissions.html
@@ -1,0 +1,23 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Yetki Tanımlama</h2>
+<form method="post">
+  <div class="mb-3">
+    <select class="form-select" name="role_id" onchange="this.form.submit()">
+      <option value="">Rol Seçin</option>
+      {% for r in roles %}<option value="{{ r.id }}" {% if role and r.id==role.id %}selected{% endif %}>{{ r.name }}</option>{% endfor %}
+    </select>
+  </div>
+  {% if role %}
+  <div class="mb-3">
+    {% for m in menus %}
+    <div class="form-check">
+      <input class="form-check-input" type="checkbox" name="menus" value="{{ m.id }}" id="m{{ m.id }}" {% if m in role.menus %}checked{% endif %}>
+      <label class="form-check-label" for="m{{ m.id }}">{{ m.module }} - {{ m.name }}</label>
+    </div>
+    {% endfor %}
+  </div>
+  <button class="btn btn-primary" type="submit">Kaydet</button>
+  {% endif %}
+</form>
+{% endblock %}

--- a/templates/manage_users.html
+++ b/templates/manage_users.html
@@ -1,0 +1,33 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Kullanıcılar</h2>
+<table class="table">
+  <tr><th>ID</th><th>Kullanıcı Adı</th><th>Rol</th><th>Departman</th><th></th></tr>
+  {% for u in users %}
+  <tr>
+    <td>{{ u.id }}</td>
+    <td>{{ u.username }}</td>
+    <td>{{ u.role.name if u.role }}</td>
+    <td>{{ u.department.name if u.department }}</td>
+    <td><a class="btn btn-sm btn-danger" href="{{ url_for('delete_user', user_id=u.id) }}">Sil</a></td>
+  </tr>
+  {% endfor %}
+</table>
+<h3>Yeni Kullanıcı</h3>
+<form method="post" action="{{ url_for('add_user') }}">
+  <div class="mb-3"><input class="form-control" name="username" placeholder="Kullanıcı Adı"></div>
+  <div class="mb-3"><input class="form-control" type="password" name="password" placeholder="Şifre"></div>
+  <div class="mb-3">
+    <select class="form-select" name="role_id">
+      {% for r in roles %}<option value="{{ r.id }}">{{ r.name }}</option>{% endfor %}
+    </select>
+  </div>
+  <div class="mb-3">
+    <select class="form-select" name="department_id">
+      <option value="">Seçiniz</option>
+      {% for d in departments %}<option value="{{ d.id }}">{{ d.name }}</option>{% endfor %}
+    </select>
+  </div>
+  <button class="btn btn-primary" type="submit">Ekle</button>
+</form>
+{% endblock %}

--- a/templates/module.html
+++ b/templates/module.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>{{ title }}</h2>
+<p>Bu sayfa sadece örnek olarak gösterilmektedir.</p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- initialize Flask app using SQLite
- add role/department/user models and permission table
- implement CRUD management for users and departments
- add permission management and protected module route
- provide HTML templates and requirements

## Testing
- `python3 -m pip install -r requirements.txt`
- `python3 app.py` *(fails: process stopped but server starts)*

------
https://chatgpt.com/codex/tasks/task_e_684fd1acea6c83328458ecdf1714746e