### PR TITLE
Add stock management with Bootstrap UI

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <title>Stok Takip</title>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
 <nav class="navbar navbar-expand-lg navbar-light bg-light">
   <div class="container-fluid">
     <a class="navbar-brand" href="{{ url_for('index') }}">Stok Takip</a>
@@ -21,3 +22,4 @@
   {% endwith %}
   {% block content %}{% endblock %}
 </div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>

--- a/templates/stocks.html
+++ b/templates/stocks.html
@@ -1,0 +1,106 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Stok Kartları</h2>
+<button class="btn btn-primary mb-2" data-bs-toggle="modal" data-bs-target="#addModal">
+  <i class="bi bi-plus"></i> Yeni Stok
+</button>
+<table class="table table-striped table-hover">
+  <thead>
+    <tr>
+      <th>Kod</th>
+      <th>İsim</th>
+      <th>Miktar</th>
+      <th>Birim</th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for s in stocks %}
+    <tr>
+      <td>{{ s.code }}</td>
+      <td>{{ s.name }}</td>
+      <td>{{ s.quantity }}</td>
+      <td>{{ s.unit }}</td>
+      <td>
+        <button class="btn btn-sm btn-warning" data-bs-toggle="modal" data-bs-target="#editModal{{s.id}}">
+          <i class="bi bi-pencil"></i>
+        </button>
+        <a class="btn btn-sm btn-danger" href="{{ url_for('delete_stock', stock_id=s.id) }}">
+          <i class="bi bi-trash"></i>
+        </a>
+      </td>
+    </tr>
+    <div class="modal fade" id="editModal{{s.id}}" tabindex="-1" aria-hidden="true">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">Stok Düzenle</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            <div class="card">
+              <div class="card-body">
+                <form method="post" action="{{ url_for('edit_stock', stock_id=s.id) }}">
+                  <div class="mb-3">
+                    <label class="form-label">Kod</label>
+                    <input class="form-control" name="code" value="{{ s.code }}">
+                  </div>
+                  <div class="mb-3">
+                    <label class="form-label">İsim</label>
+                    <input class="form-control" name="name" value="{{ s.name }}">
+                  </div>
+                  <div class="mb-3">
+                    <label class="form-label">Miktar</label>
+                    <input class="form-control" type="number" name="quantity" value="{{ s.quantity }}">
+                  </div>
+                  <div class="mb-3">
+                    <label class="form-label">Birim</label>
+                    <input class="form-control" name="unit" value="{{ s.unit }}">
+                  </div>
+                  <button class="btn btn-primary" type="submit">Kaydet</button>
+                </form>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  {% endfor %}
+  </tbody>
+</table>
+<div class="modal fade" id="addModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Yeni Stok</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div class="card">
+          <div class="card-body">
+            <form method="post" action="{{ url_for('add_stock') }}">
+              <div class="mb-3">
+                <label class="form-label">Kod</label>
+                <input class="form-control" name="code">
+              </div>
+              <div class="mb-3">
+                <label class="form-label">İsim</label>
+                <input class="form-control" name="name">
+              </div>
+              <div class="mb-3">
+                <label class="form-label">Miktar</label>
+                <input class="form-control" type="number" name="quantity">
+              </div>
+              <div class="mb-3">
+                <label class="form-label">Birim</label>
+                <input class="form-control" name="unit">
+              </div>
+              <button class="btn btn-primary" type="submit">Ekle</button>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create `Stock` model and bootstrap sample data
- implement CRUD routes for stocks
- add bootstrap icons and scripts to base template
- provide responsive stocks table with add/edit modals

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ff73316d88332895703d191aea234